### PR TITLE
Visualization of the DeeplyTough codebase

### DIFF
--- a/.codeboarding/Data Filtering and Splitting.md
+++ b/.codeboarding/Data Filtering and Splitting.md
@@ -1,0 +1,169 @@
+```mermaid
+
+graph LR
+
+    Dataset_Creation["Dataset Creation"]
+
+    Data_Filtering_and_Splitting["Data Filtering and Splitting"]
+
+    ToughM1_Dataset["ToughM1 Dataset"]
+
+    Vertex_Dataset["Vertex Dataset"]
+
+    Prospeccts_Dataset["Prospeccts Dataset"]
+
+    PdbPairVoxelizedDataset["PdbPairVoxelizedDataset"]
+
+    Dataset_Creation -- "utilizes" --> Data_Filtering_and_Splitting
+
+    Data_Filtering_and_Splitting -- "processes" --> ToughM1_Dataset
+
+    Data_Filtering_and_Splitting -- "filters against" --> Vertex_Dataset
+
+    Data_Filtering_and_Splitting -- "filters against" --> Prospeccts_Dataset
+
+    Data_Filtering_and_Splitting -- "prepares input for" --> PdbPairVoxelizedDataset
+
+    Dataset_Creation -- "initializes with data from" --> PdbPairVoxelizedDataset
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component overview details the dataset preparation and management within the DeeplyTough system. It highlights the `Dataset Creation` component as the orchestrator, which leverages `Data Filtering and Splitting` to process the `ToughM1 Dataset` and filter it against `Vertex Dataset` and `Prospeccts Dataset`. The filtered and split data is then prepared for the `PdbPairVoxelizedDataset`, which represents the final voxelized data used for training and testing.
+
+
+
+### Dataset Creation
+
+This component is responsible for the overall process of preparing and initializing the datasets used in the DeeplyTough system. It orchestrates the loading, preprocessing, and final assembly of data, leveraging specialized components for filtering and splitting to generate the training and testing datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+### Data Filtering and Splitting
+
+This component encapsulates the logic for filtering and splitting the combined protein dataset. It specifically handles the exclusion of entries from the training set based on overlap with other datasets (Vertex, ProSPECCTS) and manages the division of data into training and testing subsets, preparing them for voxelization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+### ToughM1 Dataset
+
+This component represents the ToughM1 dataset, providing methods for preprocessing and retrieving structural information. It's a core dataset used for training and testing in the DeeplyTough system.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L20-L253" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1` (20:253)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L101-L133" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.preprocess_once` (101:133)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L167-L193" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures_splits` (167:193)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L135-L165" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures` (135:165)</a>
+
+
+
+
+
+### Vertex Dataset
+
+This component handles the Vertex dataset, including its preprocessing and the retrieval of structural data. It's used to filter the training set of the ToughM1 dataset.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L18-L171" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex` (18:171)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L40-L60" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.preprocess_once` (40:60)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L62-L99" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.get_structures` (62:99)</a>
+
+
+
+
+
+### Prospeccts Dataset
+
+This component manages the ProSPECCTS dataset, providing functionalities for preprocessing and accessing structural information. Similar to the Vertex dataset, it's used to filter the training set of the ToughM1 dataset.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L16-L228" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts` (16:228)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L90-L114" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.preprocess_once` (90:114)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L141-L172" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.get_structures` (141:172)</a>
+
+
+
+
+
+### PdbPairVoxelizedDataset
+
+This component represents a voxelized dataset of PDB (Protein Data Bank) pairs. It's responsible for handling the actual data used for training and testing, including positive and negative pairs, and applying augmentations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L194-L212" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset` (194:212)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Dataset Orchestration.md
+++ b/.codeboarding/Dataset Orchestration.md
@@ -1,0 +1,213 @@
+```mermaid
+
+graph LR
+
+    Dataset_Orchestration["Dataset Orchestration"]
+
+    ToughM1_Dataset["ToughM1 Dataset"]
+
+    Vertex_Dataset["Vertex Dataset"]
+
+    Prospeccts_Dataset["Prospeccts Dataset"]
+
+    Voxelized_Dataset_Base["Voxelized Dataset Base"]
+
+    PdbTuple_Voxelized_Dataset["PdbTuple Voxelized Dataset"]
+
+    PdbPair_Voxelized_Dataset["PdbPair Voxelized Dataset"]
+
+    Dataset_Orchestration -- "initializes and populates" --> ToughM1_Dataset
+
+    Dataset_Orchestration -- "initializes and populates" --> Vertex_Dataset
+
+    Dataset_Orchestration -- "initializes and populates" --> Prospeccts_Dataset
+
+    Dataset_Orchestration -- "creates instances of" --> PdbPair_Voxelized_Dataset
+
+    PdbTuple_Voxelized_Dataset -- "inherits from" --> Voxelized_Dataset_Base
+
+    PdbPair_Voxelized_Dataset -- "inherits from" --> PdbTuple_Voxelized_Dataset
+
+    Dataset_Orchestration -- "uses for preprocessing and data retrieval" --> ToughM1_Dataset
+
+    Dataset_Orchestration -- "uses for preprocessing and data retrieval" --> Vertex_Dataset
+
+    Dataset_Orchestration -- "uses for preprocessing and data retrieval" --> Prospeccts_Dataset
+
+    PdbTuple_Voxelized_Dataset -- "extracts data using" --> Voxelized_Dataset_Base
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This graph illustrates the `Dataset Orchestration` component's role in preparing protein structure datasets for model consumption. It shows how `Dataset Orchestration` integrates and processes raw data from `ToughM1`, `Vertex`, and `Prospeccts` datasets, and then initializes specialized `PdbPair Voxelized Dataset` instances. The `PdbPair Voxelized Dataset` and `PdbTuple Voxelized Dataset` components are built upon the `Voxelized Dataset Base`, demonstrating a clear inheritance hierarchy for handling voxelized data.
+
+
+
+### Dataset Orchestration
+
+This component is responsible for the high-level orchestration of dataset creation. It integrates various raw protein structure datasets, handles filtering and splitting, and initializes the specialized voxelized datasets for consumption by the model.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+### ToughM1 Dataset
+
+This component manages the ToughM1 dataset, including its preprocessing and the retrieval of structural data. It provides methods to get structures and split them for training and testing purposes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L20-L253" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1` (20:253)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L101-L133" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.preprocess_once` (101:133)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L167-L193" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures_splits` (167:193)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L135-L165" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures` (135:165)</a>
+
+
+
+
+
+### Vertex Dataset
+
+This component handles the Vertex dataset, including its preprocessing and the retrieval of structural data. It provides methods to get structures and preprocess them.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L18-L171" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex` (18:171)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L40-L60" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.preprocess_once` (40:60)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L62-L99" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.get_structures` (62:99)</a>
+
+
+
+
+
+### Prospeccts Dataset
+
+This component manages the Prospeccts dataset, including its preprocessing and the retrieval of structural data. It provides methods to get structures and preprocess them, and also defines the internal paths for Prospeccts data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L16-L228" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts` (16:228)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L90-L114" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.preprocess_once` (90:114)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L141-L172" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.get_structures` (141:172)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L116-L139" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts._prospeccts_paths` (116:139)</a>
+
+
+
+
+
+### Voxelized Dataset Base
+
+This is the base component for voxelized datasets, providing core functionalities for sampling augmentations, extracting volumes, and getting occupancy information. It serves as a foundational class for more specific voxelized dataset implementations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L19-L116" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset` (19:116)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L26-L52" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset.__init__` (26:52)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L60-L73" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._sample_augmentation` (60:73)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L75-L96" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._extract_volume` (75:96)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L99-L116" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._getOccupancyC` (99:116)</a>
+
+
+
+
+
+### PdbTuple Voxelized Dataset
+
+This component extends the Voxelized Dataset Base and is responsible for handling voxelized PDB tuple data. It provides methods for initializing the dataset and extracting patches from the voxelized data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L119-L191" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset` (119:191)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L122-L150" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset.__init__` (122:150)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L152-L191" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset._get_patch` (152:191)</a>
+
+
+
+
+
+### PdbPair Voxelized Dataset
+
+This component specializes in handling voxelized PDB pair data. It inherits from PdbTupleVoxelizedDataset and is used to create datasets for training and testing, specifically for pairs of PDB structures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L194-L212" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset` (194:212)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L197-L199" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset.__len__` (197:199)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Pair Data Management.md
+++ b/.codeboarding/Pair Data Management.md
@@ -1,0 +1,175 @@
+```mermaid
+
+graph LR
+
+    Dataset_Orchestrator["Dataset Orchestrator"]
+
+    ToughM1_Data_Handler["ToughM1 Data Handler"]
+
+    Vertex_Data_Handler["Vertex Data Handler"]
+
+    Prospeccts_Data_Handler["Prospeccts Data Handler"]
+
+    Voxelized_Dataset_Generator["Voxelized Dataset Generator"]
+
+    Pair_Data_Management["Pair Data Management"]
+
+    Dataset_Orchestrator -- "invokes" --> ToughM1_Data_Handler
+
+    Dataset_Orchestrator -- "invokes" --> Vertex_Data_Handler
+
+    Dataset_Orchestrator -- "invokes" --> Prospeccts_Data_Handler
+
+    Dataset_Orchestrator -- "creates" --> Voxelized_Dataset_Generator
+
+    ToughM1_Data_Handler -- "provides data to" --> Dataset_Orchestrator
+
+    Vertex_Data_Handler -- "provides data to" --> Dataset_Orchestrator
+
+    Prospeccts_Data_Handler -- "provides data to" --> Dataset_Orchestrator
+
+    Voxelized_Dataset_Generator -- "consumes data from" --> Dataset_Orchestrator
+
+    Dataset_Orchestrator -- "manages" --> Pair_Data_Management
+
+    Pair_Data_Management -- "provides data to" --> Voxelized_Dataset_Generator
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This system orchestrates the creation of the TOUGH dataset, which involves preprocessing various sub-datasets (ToughM1, Vertex, Prospeccts), filtering data based on exclusion criteria, and constructing voxelized training and testing datasets. It manages the reading and preparation of positive and negative pocket pairs, shuffles them, and then uses these pairs along with processed PDB structures to generate the final voxelized datasets for training and testing, incorporating augmentation techniques.
+
+
+
+### Dataset Orchestrator
+
+This component is responsible for orchestrating the creation of the TOUGH dataset, including preprocessing various sub-datasets (ToughM1, Vertex, Prospeccts), filtering data based on exclusion criteria, and finally constructing the voxelized training and testing datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+### ToughM1 Data Handler
+
+This component handles the preprocessing and splitting of the ToughM1 dataset, providing the core structures for training and testing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L20-L253" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.toughm1.ToughM1` (20:253)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L101-L133" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.toughm1.ToughM1.preprocess_once` (101:133)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L167-L193" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.toughm1.ToughM1.get_structures_splits` (167:193)</a>
+
+
+
+
+
+### Vertex Data Handler
+
+This component manages the Vertex dataset, including its preprocessing and retrieval of structures, which can then be used to filter the main training dataset.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L18-L171" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.vertex.Vertex` (18:171)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L40-L60" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.vertex.Vertex.preprocess_once` (40:60)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L62-L99" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.vertex.Vertex.get_structures` (62:99)</a>
+
+
+
+
+
+### Prospeccts Data Handler
+
+This component is responsible for handling the Prospeccts dataset, including preprocessing and retrieving structures, which are used to filter the main training dataset.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L16-L228" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.prospeccts.Prospeccts` (16:228)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L90-L114" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.prospeccts.Prospeccts.preprocess_once` (90:114)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L141-L172" target="_blank" rel="noopener noreferrer">`deeplytough.datasets.prospeccts.Prospeccts.get_structures` (141:172)</a>
+
+
+
+
+
+### Voxelized Dataset Generator
+
+This component is responsible for creating the final voxelized dataset instances (training and testing) from the processed PDB pairs and structures, applying various augmentation techniques.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L194-L212" target="_blank" rel="noopener noreferrer">`deeplytough.engine.datasets.PdbPairVoxelizedDataset` (194:212)</a>
+
+
+
+
+
+### Pair Data Management
+
+This component is responsible for reading, preparing, and managing positive and negative pocket pairs from predefined lists, including shuffling them for dataset construction.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Raw Protein Data Management.md
+++ b/.codeboarding/Raw Protein Data Management.md
@@ -1,0 +1,215 @@
+```mermaid
+
+graph LR
+
+    Raw_Protein_Data_Management["Raw Protein Data Management"]
+
+    Dataset_Orchestrator["Dataset Orchestrator"]
+
+    TOUGH_M1_Data_Handler["TOUGH-M1 Data Handler"]
+
+    Vertex_Data_Handler["Vertex Data Handler"]
+
+    ProSPECCTS_Data_Handler["ProSPECCTS Data Handler"]
+
+    Custom_Data_Handler["Custom Data Handler"]
+
+    Dataset_Orchestrator -- "initializes and uses" --> TOUGH_M1_Data_Handler
+
+    Dataset_Orchestrator -- "initializes and uses" --> Vertex_Data_Handler
+
+    Dataset_Orchestrator -- "initializes and uses" --> ProSPECCTS_Data_Handler
+
+    TOUGH_M1_Data_Handler -- "provides data to" --> Dataset_Orchestrator
+
+    Vertex_Data_Handler -- "provides data to" --> Dataset_Orchestrator
+
+    ProSPECCTS_Data_Handler -- "provides data to" --> Dataset_Orchestrator
+
+    Raw_Protein_Data_Management -- "is composed of" --> TOUGH_M1_Data_Handler
+
+    Raw_Protein_Data_Management -- "is composed of" --> Vertex_Data_Handler
+
+    Raw_Protein_Data_Management -- "is composed of" --> ProSPECCTS_Data_Handler
+
+    Raw_Protein_Data_Management -- "is composed of" --> Custom_Data_Handler
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem is responsible for the comprehensive management of raw protein data, encompassing initial preprocessing, retrieval, and organization from diverse datasets such as TOUGH-M1, Vertex, ProSPECCTS, and custom sources. It orchestrates the preparation of these datasets for downstream tasks, including data splitting, filtering, and the initialization of voxelized datasets for model training and evaluation. The core functionality revolves around specialized data handlers for each dataset type, ensuring data integrity and readiness for analysis.
+
+
+
+### Raw Protein Data Management
+
+This component manages the initial preprocessing and retrieval of protein structures from various raw datasets, including TOUGH-M1, Vertex, ProSPECCTS, and custom datasets. It acts as an overarching conceptual component for all individual data handlers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L20-L253" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1` (20:253)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L101-L133" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.preprocess_once` (101:133)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L167-L193" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures_splits` (167:193)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L18-L171" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex` (18:171)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L40-L60" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.preprocess_once` (40:60)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L62-L99" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.get_structures` (62:99)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L16-L228" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts` (16:228)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L90-L114" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.preprocess_once` (90:114)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L141-L172" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.get_structures` (141:172)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/custom.py#L17-L19" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.custom.Custom.preprocess_once` (17:19)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/custom.py#L21-L44" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.custom.Custom.get_structures` (21:44)</a>
+
+
+
+
+
+### Dataset Orchestrator
+
+This component is responsible for orchestrating the creation and preparation of the TOUGH-M1 dataset, integrating data from various sources like TOUGH-M1, Vertex, and ProSPECCTS. It handles preprocessing, data splitting into training and testing sets, and filtering based on specified criteria (e.g., excluding entries present in other datasets). It also initializes the final voxelized dataset for model training and evaluation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L194-L212" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset` (194:212)</a>
+
+
+
+
+
+### TOUGH-M1 Data Handler
+
+This component manages the TOUGH-M1 dataset, including its preprocessing, structure retrieval, and splitting into training and testing subsets. It handles tasks like running `fpocket2` for pocket identification, mapping PDB chains to UniProt accessions, and evaluating pocket matching performance using AUC metrics.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L20-L253" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1` (20:253)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L101-L133" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.preprocess_once` (101:133)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L167-L193" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures_splits` (167:193)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L135-L165" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures` (135:165)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L29-L99" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1._preprocess_worker` (29:99)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L195-L253" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.evaluate_matching` (195:253)</a>
+
+
+
+
+
+### Vertex Data Handler
+
+This component is responsible for handling the Vertex dataset. Its primary functions include preprocessing the dataset and retrieving the structural information, which can then be used by the Dataset Orchestrator for filtering the main TOUGH-M1 training set.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L18-L171" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex` (18:171)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L40-L60" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.preprocess_once` (40:60)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L62-L99" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.get_structures` (62:99)</a>
+
+
+
+
+
+### ProSPECCTS Data Handler
+
+This component manages the ProSPECCTS dataset. It provides functionalities for preprocessing the dataset and retrieving its structural data. Similar to the Vertex Data Handler, its output is utilized by the Dataset Orchestrator to refine the TOUGH-M1 training set by excluding overlapping entries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L16-L228" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts` (16:228)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L90-L114" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.preprocess_once` (90:114)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L141-L172" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.get_structures` (141:172)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L49-L88" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts._extract_pocket_and_get_uniprot` (49:88)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L25-L46" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts._get_pdb_code_from_raw_pdb` (25:46)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L116-L139" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts._prospeccts_paths` (116:139)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L174-L228" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.evaluate_matching` (174:228)</a>
+
+
+
+
+
+### Custom Data Handler
+
+This component provides basic functionalities for handling custom datasets, specifically for preprocessing and retrieving structural information. While not directly involved in the `create_tough_dataset` flow shown in the CFG, it represents a generic interface for custom data integration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/custom.py#L4-L67" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.custom.Custom` (4:67)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/custom.py#L17-L19" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.custom.Custom.preprocess_once` (17:19)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/custom.py#L21-L44" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.custom.Custom.get_structures` (21:44)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Voxelized Data Processing.md
+++ b/.codeboarding/Voxelized Data Processing.md
@@ -1,0 +1,133 @@
+```mermaid
+
+graph LR
+
+    Voxelized_Dataset_Core["Voxelized Dataset Core"]
+
+    PDB_Tuple_Dataset["PDB Tuple Dataset"]
+
+    PDB_Pair_Dataset["PDB Pair Dataset"]
+
+    Point_of_Interest_Dataset["Point of Interest Dataset"]
+
+    PDB_Tuple_Dataset -- "initializes via" --> Voxelized_Dataset_Core
+
+    PDB_Tuple_Dataset -- "applies augmentation using" --> Voxelized_Dataset_Core
+
+    PDB_Tuple_Dataset -- "extracts volume using" --> Voxelized_Dataset_Core
+
+    PDB_Pair_Dataset -- "retrieves patches from" --> PDB_Tuple_Dataset
+
+    Point_of_Interest_Dataset -- "initializes via" --> Voxelized_Dataset_Core
+
+    Point_of_Interest_Dataset -- "extracts volume using" --> Voxelized_Dataset_Core
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem, 'Voxelized Data Processing', provides foundational functionalities for handling and generating voxelized protein data. It includes abstract base classes for voxelized datasets, specialized datasets for PDB tuples and pairs, and datasets for points of interest. The core functionalities involve extracting volumetric data, sampling augmentations, managing occupancy grids, and constructing specialized voxelized datasets.
+
+
+
+### Voxelized Dataset Core
+
+This is an abstract base class for datasets of voxelized proteins. It provides core functionalities for handling PDB lists, defining box sizes, and implementing data augmentation techniques like rotation and mirroring. It also includes methods for extracting voxelized volumes from atomic coordinates and channels, and for calling a C function to compute occupancy values.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L19-L116" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset` (19:116)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L26-L52" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset.__init__` (26:52)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L75-L96" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._extract_volume` (75:96)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L99-L116" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._getOccupancyC` (99:116)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L60-L73" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._sample_augmentation` (60:73)</a>
+
+
+
+
+
+### PDB Tuple Dataset
+
+This class extends VoxelizedDataset and is an abstract base class for datasets of tuples of subvolumes of voxelized proteins. It manages positive and negative pairs of PDB entries, filters them based on available PDBs, and provides a method to get a voxelized patch around a specified center, including options for decoy points and robustness augmentation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L119-L191" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset` (119:191)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L122-L150" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset.__init__` (122:150)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L152-L191" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset._get_patch` (152:191)</a>
+
+
+
+
+
+### PDB Pair Dataset
+
+This class inherits from PdbTupleVoxelizedDataset and specifically handles datasets of pairs of voxelized pockets. It determines whether a pair is positive or negative and retrieves the corresponding voxelized patches for each member of the pair.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L194-L212" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset` (194:212)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L201-L212" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset.__getitem__` (201:212)</a>
+
+
+
+
+
+### Point of Interest Dataset
+
+This class extends VoxelizedDataset and is designed for datasets of voxelized subvolumes around specific points of interest within proteins. It initializes with a list of PDBs and corresponding extraction points, and its __getitem__ method extracts voxelized volumes for each specified point.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L215-L233" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PointOfInterestVoxelizedDataset` (215:233)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L218-L220" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PointOfInterestVoxelizedDataset.__init__` (218:220)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L222-L233" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PointOfInterestVoxelizedDataset.__getitem__` (222:233)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,199 @@
+```mermaid
+
+graph LR
+
+    Dataset_Orchestration["Dataset Orchestration"]
+
+    Raw_Protein_Data_Management["Raw Protein Data Management"]
+
+    Voxelized_Data_Processing["Voxelized Data Processing"]
+
+    Data_Filtering_and_Splitting["Data Filtering and Splitting"]
+
+    Pair_Data_Management["Pair Data Management"]
+
+    Dataset_Orchestration -- "orchestrates" --> Raw_Protein_Data_Management
+
+    Dataset_Orchestration -- "consumes data from" --> Raw_Protein_Data_Management
+
+    Dataset_Orchestration -- "applies" --> Data_Filtering_and_Splitting
+
+    Dataset_Orchestration -- "manages" --> Data_Filtering_and_Splitting
+
+    Dataset_Orchestration -- "initializes" --> Voxelized_Data_Processing
+
+    Dataset_Orchestration -- "configures" --> Voxelized_Data_Processing
+
+    Dataset_Orchestration -- "uses" --> Pair_Data_Management
+
+    Dataset_Orchestration -- "integrates" --> Pair_Data_Management
+
+    Raw_Protein_Data_Management -- "provides raw data to" --> Voxelized_Data_Processing
+
+    Data_Filtering_and_Splitting -- "prepares data for" --> Voxelized_Data_Processing
+
+    Pair_Data_Management -- "supplies pairs to" --> Voxelized_Data_Processing
+
+    click Dataset_Orchestration href "https://github.com/benevolentAI/DeeplyTough/blob/main/.codeboarding//Dataset Orchestration.md" "Details"
+
+    click Raw_Protein_Data_Management href "https://github.com/benevolentAI/DeeplyTough/blob/main/.codeboarding//Raw Protein Data Management.md" "Details"
+
+    click Voxelized_Data_Processing href "https://github.com/benevolentAI/DeeplyTough/blob/main/.codeboarding//Voxelized Data Processing.md" "Details"
+
+    click Data_Filtering_and_Splitting href "https://github.com/benevolentAI/DeeplyTough/blob/main/.codeboarding//Data Filtering and Splitting.md" "Details"
+
+    click Pair_Data_Management href "https://github.com/benevolentAI/DeeplyTough/blob/main/.codeboarding//Pair Data Management.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This architecture describes the data processing pipeline for the DeeplyTough project, focusing on the preparation of protein structure datasets for machine learning models. The main flow involves orchestrating the ingestion and preprocessing of various raw protein datasets, transforming them into a voxelized format, and applying filtering and splitting logic to prepare training and testing sets. The system ensures that diverse protein data sources are harmonized and made ready for consumption by downstream analytical or model training components.
+
+
+
+### Dataset Orchestration
+
+This component is responsible for the high-level orchestration of dataset creation. It integrates various raw protein structure datasets, handles filtering and splitting, and initializes the specialized voxelized datasets for consumption by the model.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+### Raw Protein Data Management
+
+This component manages the initial preprocessing and retrieval of protein structures from various raw datasets, including TOUGH-M1, Vertex, ProSPECCTS, and custom datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L20-L253" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1` (20:253)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L101-L133" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.preprocess_once` (101:133)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/toughm1.py#L167-L193" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.toughm1.ToughM1.get_structures_splits` (167:193)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L18-L171" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex` (18:171)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L40-L60" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.preprocess_once` (40:60)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/vertex.py#L62-L99" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.vertex.Vertex.get_structures` (62:99)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L16-L228" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts` (16:228)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L90-L114" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.preprocess_once` (90:114)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/prospeccts.py#L141-L172" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.prospeccts.Prospeccts.get_structures` (141:172)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/custom.py#L17-L19" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.custom.Custom.preprocess_once` (17:19)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/datasets/custom.py#L21-L44" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.datasets.custom.Custom.get_structures` (21:44)</a>
+
+
+
+
+
+### Voxelized Data Processing
+
+This component provides foundational functionalities for handling and generating voxelized protein data, including extracting volumetric data, sampling augmentations, managing occupancy grids, and constructing specialized voxelized datasets like PDB tuples and pairs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L26-L52" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset.__init__` (26:52)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L75-L96" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._extract_volume` (75:96)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L99-L116" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._getOccupancyC` (99:116)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L60-L73" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.VoxelizedDataset._sample_augmentation` (60:73)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L122-L150" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset.__init__` (122:150)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L152-L191" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbTupleVoxelizedDataset._get_patch` (152:191)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L194-L212" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset` (194:212)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L201-L212" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PdbPairVoxelizedDataset.__getitem__` (201:212)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L218-L220" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PointOfInterestVoxelizedDataset.__init__` (218:220)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L222-L233" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.PointOfInterestVoxelizedDataset.__getitem__` (222:233)</a>
+
+
+
+
+
+### Data Filtering and Splitting
+
+This component encapsulates the logic for filtering and splitting the combined protein dataset. It specifically handles the exclusion of entries from the training set based on overlap with other datasets and manages the division of data into training and testing subsets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+### Pair Data Management
+
+This component is responsible for reading, preparing, and managing positive and negative pocket pairs from predefined lists, including shuffling them for dataset construction.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+- <a href="https://github.com/benevolentAI/DeeplyTough/blob/master/deeplytough/engine/datasets.py#L236-L315" target="_blank" rel="noopener noreferrer">`DeeplyTough.deeplytough.engine.datasets.create_tough_dataset` (236:315)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the DeeplyTough codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/DeeplyTough/on_boarding.md

The idea of these diagrams is to help people get up-to-speed with the codebase. I know that a lot of scientists interact with these codebases and I suppose they can make use of such diagrams and grasp the idea much faster than reading the code itself. I would love to hear what do you think about Diagram first documentation for on-boarding and if it fits in your existing on-boarding processes.

Any feedback is more than welcome! We also have a free github action out now, which can fully-automatically update the docs (let me know what you think about that).

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.